### PR TITLE
correct tp@example.com to "to@example.com" in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Mailer uses ```gen_smtp``` to provide the mailing infrastructure.
 First compose an email with:
 
 ```elixir
-  email = Mailer.compose("from@example.com", tp@example.com, "Subject", "welcome_template", template_data)
+  email = Mailer.compose("from@example.com", "to@example.com", "Subject", "welcome_template", template_data)
 ```
 
 Then send the email with:
@@ -122,7 +122,7 @@ priv/templates/welcome/fr/welcome.html
 By including the country code in the compose call, Mailer will render the correct localised template.
 
 ```elixir
-Mailer.compose("from@example.com", tp@example.com, "Subject", "welcome", data, "en")
+Mailer.compose("from@example.com", "to@example.com", "Subject", "welcome", data, "en")
 ```
 
 # Author


### PR DESCRIPTION
It appears that `tp@example.com` should be a string literal like `"to@example.com"` in the README
I was using this library for the first time and encountered a compiler error with this argument
