### PR TITLE
Add VERSION file to the package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -60,7 +60,7 @@ defmodule Mailer.Mixfile do
 
   defp package do
     [
-      files:        ["lib", "priv", "mix.exs", "README.md", "LICENCE.txt"],
+      files:        ["lib", "priv", "mix.exs", "README.md", "LICENCE.txt", "VERSION"],
       maintainers:  ["Antony Pinchbeck", "Yurii Rashkovskii", "Paul Scarrone", "sldab", "mogadget", "Miguel Martins", "Mike Janger"],
       licenses:     ["apache 2 license"],
       links:        %{


### PR DESCRIPTION
Currently mailer hex package can't be used as dependency, errors out when Mailer.Mixfile.version is called.
