### PR TITLE
upgrading to timex 2.1.0

### DIFF
--- a/lib/mailer.ex
+++ b/lib/mailer.ex
@@ -1,6 +1,7 @@
 defmodule Mailer do
   alias Mailer.Email.Plain
   alias Mailer.Email.Multipart
+  alias Mailer.Util
 
   @moduledoc """
   A simple SMTP mailer.
@@ -133,8 +134,7 @@ defmodule Mailer do
 
   @doc false
   defp compose_email_by_type(from, to, subject, [{:text, plain}], data) do
-    date = Timex.Date.local
-    date = Timex.DateFormat.format!(date, "%a, %d %b %Y %T %z", :strftime)
+    date = Util.localtime_to_str
 
     body = Mail.Renderer.render(plain, data)
 
@@ -150,8 +150,7 @@ defmodule Mailer do
 
   @doc false
   defp compose_email_by_type(from, to, subject, [{:html, html}, {:text, plain}], data) do
-    date = Timex.Date.local
-    date = Timex.DateFormat.format!(date, "%a, %d %b %Y %T %z", :strftime)
+    date = Util.localtime_to_str
 
     plain_text = Mail.Renderer.render(plain, data)
     html_text = Mail.Renderer.render(html, data)

--- a/lib/mailer/util.ex
+++ b/lib/mailer/util.ex
@@ -1,5 +1,10 @@
 defmodule Mailer.Util do
 
+  def localtime_to_str() do
+    date = Timex.DateTime.local
+    Timex.format!(date, "%a, %d %m %Y %T %z", :strftime)
+  end
+
   def get_domain(address) do
     addr = case String.split(address, ~r([<>])) do
       [_name, addr, ""] -> addr

--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,7 @@ defmodule Mailer.Mixfile do
   defp deps do
     [
       {:gen_smtp, "~> 0.9.0"},
-      {:timex, "~> 1.0.0"},
+      {:timex, "~> 2.1.0"},
       {:ex_doc, "~> 0.11.4", only: :dev},
       {:earmark, ">= 0.2.1", only: :dev}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -10,5 +10,5 @@
   "mimerl": {:hex, :mimerl, "1.0.2"},
   "rebar3_hex": {:hex, :rebar3_hex, "0.9.0"},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
-  "timex": {:hex, :timex, "1.0.0"},
+  "timex": {:hex, :timex, "2.1.0"},
   "tzdata": {:hex, :tzdata, "0.5.6"}}

--- a/test/mailer/email_multipart_test.exs
+++ b/test/mailer/email_multipart_test.exs
@@ -2,6 +2,7 @@ defmodule Mailer.Email.Multipart.Test do
   use ExUnit.Case
 
   alias Mailer.Email.Multipart, as: Email
+  alias Mailer.Util
 
   test "can set the from and domain fields" do
     email = Email.create
@@ -62,8 +63,7 @@ defmodule Mailer.Email.Multipart.Test do
   end
 
   test "will compose the email" do
-    date = Timex.Date.local
-    date = Timex.DateFormat.format!(date, "%a, %d %m %Y %T %z", :strftime)
+    date = Util.localtime_to_str
 
     email = Email.create
 
@@ -121,8 +121,7 @@ composed = {"multipart", "alternative",
   end
 
   test "will decompose the email" do
-    date = Timex.Date.local
-    date = Timex.DateFormat.format!(date, "%a, %d %m %Y %T %z", :strftime)
+    date = Util.localtime_to_str
     email_src = Email.create
 
     email_src = Email.add_from(email_src, "from@example.com")

--- a/test/mailer/email_plain_test.exs
+++ b/test/mailer/email_plain_test.exs
@@ -2,6 +2,7 @@ defmodule Mailer.Email.Plain.Test do
   use ExUnit.Case
 
   alias Mailer.Email.Plain
+  alias Mailer.Util
 
   test "can set the from and domain fields" do
     email = Plain.create
@@ -55,8 +56,7 @@ defmodule Mailer.Email.Plain.Test do
 
 
   test "will compose the email" do
-    date = Timex.Date.local
-    date = Timex.DateFormat.format!(date, "%a, %d %m %Y %T %z", :strftime)
+    date = Util.localtime_to_str
     email = Plain.create
 
     email = Plain.add_from(email, "from@example.com")
@@ -91,8 +91,7 @@ defmodule Mailer.Email.Plain.Test do
   end
 
   test "will decompose the email" do
-    date = Timex.Date.local
-    date = Timex.DateFormat.format!(date, "%a, %d %m %Y %T %z", :strftime)
+    date = Util.localtime_to_str
     email_src = Plain.create
 
     email_src = Plain.add_from(email_src, "from@example.com")

--- a/test/mailer/mailer_test.exs
+++ b/test/mailer/mailer_test.exs
@@ -3,6 +3,7 @@ defmodule Mailer.Client.Test do
 
   alias Mailer.Email.Plain
   alias Mailer.Email.Multipart
+  alias Mailer.Util
 
   setup_all do
     Test.Transport.start
@@ -12,8 +13,7 @@ defmodule Mailer.Client.Test do
 
   test "It will send plain text email" do
 
-    date = Timex.Date.local
-    date = Timex.DateFormat.format!(date, "%a, %d %b %Y %T %z", :strftime)
+    date = Util.localtime_to_str
     email = Plain.create
 
     email = Plain.add_from(email, "from@example.com")
@@ -40,8 +40,7 @@ defmodule Mailer.Client.Test do
 
   test "It will send multipart email" do
 
-    date = Timex.Date.local
-    date = Timex.DateFormat.format!(date, "%a, %d %b %Y %T %z", :strftime)
+    date = Util.localtime_to_str
     email = Multipart.create
 
     email = Multipart.add_from(email, "from@example.com")


### PR DESCRIPTION
Hello,

This pull updates the Timex library to its latest version (2.1.0). The 2.x series seem to have a lot of improvements in performance, stability, and bug fixes.

Also, these 2 lines of code:

``` elixir
date = Timex.Date.local
date = Timex.DateFormat.format!(date, "%a, %d %b %Y %T %z", :strftime)
```

were repeated in different places, so I took the liberty of moving them into its own function inside the `Mailer.Util` module so it can be reused. 

Any thoughts?

Thanks in advance! 
