### PR TITLE
fix date to conform to rfc822

### DIFF
--- a/lib/mailer/util.ex
+++ b/lib/mailer/util.ex
@@ -2,7 +2,7 @@ defmodule Mailer.Util do
 
   def localtime_to_str() do
     date = Timex.DateTime.local
-    Timex.format!(date, "%a, %d %m %Y %T %z", :strftime)
+    Timex.format!(date, "{RFC822}")
   end
 
   def get_domain(address) do


### PR DESCRIPTION
The date header which conforms to RFC822 have to use `Jan, Feb, ...` for the month. In some MUA, Thunderbird for instance, cannot correctly parse the date which doesn't conforms to RFC822.
