### PR TITLE
Upgrade to timex 3.x

### DIFF
--- a/lib/mailer/util.ex
+++ b/lib/mailer/util.ex
@@ -1,7 +1,7 @@
 defmodule Mailer.Util do
 
   def localtime_to_str() do
-    date = Timex.DateTime.local
+    date = Timex.local
     Timex.format!(date, "%a, %d %m %Y %T %z", :strftime)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Mailer.Mixfile do
     [
       app: :mailer,
       version: version,
-      elixir: "~> 1.2",
+      elixir: "~> 1.3",
       elixirc_paths: elixirc_paths(Mix.env),
       deps: deps,
       description: description,
@@ -46,7 +46,7 @@ defmodule Mailer.Mixfile do
   defp deps do
     [
       {:gen_smtp, "~> 0.9.0"},
-      {:timex, "~> 2.1.0"},
+      {:timex, "~> 3.0.0"},
       {:ex_doc, "~> 0.11.4", only: :dev},
       {:earmark, ">= 0.2.1", only: :dev}
     ]


### PR DESCRIPTION
Hello!

Timex 3.x is out, so I thought an upgrade would be nice. The change is rather small, although Elixir +1.3.x is now required due to the use of new native types.

Any thoughts?

Thank you!

Best,
