### PR TITLE
Updating gen_smtp dependency to 0.11.0 as older version doesn't compile

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,7 @@ defmodule Mailer.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [
-      {:gen_smtp, "~> 0.9.0"},
+      {:gen_smtp, "~> 0.11.0"},
       {:timex, "~> 2.1.0"},
       {:ex_doc, "~> 0.11.4", only: :dev},
       {:earmark, ">= 0.2.1", only: :dev}


### PR DESCRIPTION
gen_smtp 0.9.0 doesn't compile in erlang v19. Updated the dependency to gen_smtp 0.11.0
